### PR TITLE
Fix npmignore and type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ bower_components
 .npmrc
 .lock-wscript
 .svn
+.idea
 .wafpickle-*
 config.gypi
 CVS

--- a/.npmignore
+++ b/.npmignore
@@ -3,6 +3,7 @@
 
 # but not these files...
 !getStats.js
+!getStats.d.ts
 !getStats.min.js
 !index.html
 !package.json

--- a/getStats.d.ts
+++ b/getStats.d.ts
@@ -24,13 +24,17 @@ declare module 'getstats' {
     codecs: string[];
     availableBandwidth: string;
     streams: number;
+    framerateMean: number;
+    bitrateMean: number;
   }
 
   interface GetStatsConnectionStream {
     send: GetStatsConnectionInfo;
     recv: GetStatsConnectionInfo;
-    bytesSend: number;
+    bytesSent: number;
     bytesReceived: number;
+    latency: number;
+    packetsLost: number;
   }
 
   interface GetStatsNetworkInfo {
@@ -58,7 +62,7 @@ declare module 'getstats' {
     recv: GetStatsResolution;
   }
 
-  interface GetStatsResult {
+  export interface GetStatsResult {
     datachannel: {
       state: 'open' | 'close';
     };
@@ -74,10 +78,9 @@ declare module 'getstats' {
     nomore: () => void;
   }
 
-  function getstats(
-    rtc: RTCPeerConnection,
-    callback: (result: GetStatsResult) => void,
+  export default function getstats(
+      rtc: RTCPeerConnection,
+      callback: (result: GetStatsResult) => void,
+      interval?: number
   ): void;
-
-  export = getstats;
 }


### PR DESCRIPTION
- Do not ignore getStats.d.js
- Updated Types:
-- Fixed bytesSend to byteSent
-- Added interval to GetStats function
-- Added framerateMean and bitrateMean, latency and packatesLost
-- Export of GetStatsResult